### PR TITLE
Fixes sign out bug [TR #105]

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -37,7 +37,7 @@ header
                   li
                     = link_to "Manage Pirates", users_path
                   li
-                    = button_to "Sign Out", destroy_user_session_path, method: :delete, class: "sign-out"
+                    = button_to "Sign Out", destroy_user_session_path, method: :get, class: "sign-out"
                 - else
                   li
                     = link_to "Sign in", new_user_session_path


### PR DESCRIPTION
This looks like it might be a subtle change introduced by Rails 5. The
sign out operation used to be a call to destroy_user_session_path,
method: :delete but now the method is :get

The sign out test was failing and I know it was working prior to the
upgrade.