### PR TITLE
Removes usage of #text from feature step code [TR#86+#87] 

### DIFF
--- a/features/sign_in.feature
+++ b/features/sign_in.feature
@@ -24,8 +24,8 @@ Feature: Sign-In
     And I enter an unregistered email
     And I enter an invalid password
     And I click Sign In
-    Then I see an alert containing "Invalid email or password"
+    Then I see an alert containing "Invalid Email or password"
     When I enter a registered email
     And I enter an invalid password
     And I click Sign In
-    Then I see an alert containing "Invalid email or password"
+    Then I see an alert containing "Invalid Email or password"

--- a/features/steps/gig_management.rb
+++ b/features/steps/gig_management.rb
@@ -25,13 +25,11 @@ class Spinach::Features::GigManagement < Spinach::FeatureSteps
   end
 
   step 'I am on the Manage Gigs page' do
-    sync_title("Manage Gigs")
-    expect(page.title).to have_content("Manage Gigs")
+    expect(page).to have_title("Manage Gigs")
   end
 
   step 'I see the Add Gig page' do
-    sync_title("Add Gig")
-    expect(page.title).to have_content("Add Gig")
+    expect(page).to have_title("Add Gig")
   end
 
   step 'I see a note describing tokens' do
@@ -57,7 +55,6 @@ class Spinach::Features::GigManagement < Spinach::FeatureSteps
 
   step 'I click Add Gig' do
     click_link_or_button "Add gig"
-    sync_page
   end
 
   step 'I click Manage Gigs' do
@@ -108,7 +105,6 @@ class Spinach::Features::GigManagement < Spinach::FeatureSteps
     my_accept_alert do
       find(".gig-id-#{@gig.id}").click_link("Delete")
     end
-    sync_page
   end
 
   step 'that gig is deleted' do
@@ -124,8 +120,7 @@ class Spinach::Features::GigManagement < Spinach::FeatureSteps
   end
 
   step 'I am sent to the Change Gig page' do
-    sync_title("Modify Gig Info")
-    expect(page.title).to have_content("Modify Gig Info")
+    expect(page).to have_title("Modify Gig Info")
   end
 
   step 'I am sent to the Sign In page' do
@@ -146,15 +141,14 @@ class Spinach::Features::GigManagement < Spinach::FeatureSteps
 
   step 'I click Update' do
     click_on "Update"
-    sync_page
   end
 
   step 'the gig fields are changed' do
     within find(".gig-id-#{@gig.id}") do
-      expect(find("span.gig_name").text).to     match(change(@gig.name))
-      expect(find("span.gig_note").text).to     match(change(@gig.note))
-      expect(find("span.gig_date").text).to     match(Date.parse(@changed_date).strftime('%b %-d:'))
-      expect(find("span.gig_location").text).to match(change(@gig.location))
+      expect(find("span.gig_name")).to     have_content(change(@gig.name))
+      expect(find("span.gig_note")).to     have_content(change(@gig.note))
+      expect(find("span.gig_date")).to     have_content(Date.parse(@changed_date).strftime('%b %-d:'))
+      expect(find("span.gig_location")).to have_content(change(@gig.location))
     end
   end
 
@@ -287,13 +281,5 @@ class Spinach::Features::GigManagement < Spinach::FeatureSteps
 
   def verify_gig_active(gig)
     expect(page).not_to have_css(".gig-id-#{gig.id}.expired")
-  end
-
-  def sync_title(text)
-    sync_page
-    while page.title != text
-      puts "title = #{page.title}. sleeping..."
-      sync_page
-    end
   end
 end

--- a/features/steps/sign_in.rb
+++ b/features/steps/sign_in.rb
@@ -9,12 +9,12 @@ class Spinach::Features::SignIn < Spinach::FeatureSteps
   step 'I navigate to the Sign In page' do
     find("li.navigation").hover
     i_click_sign_in
-    expect(page.title).to eq("Sign In")
+    expect(page).to have_title("Sign In")
   end
 
   step 'I am sent to the Profile page' do
-    expect(page.title).to eq("Motley User")
-    expect(page.text).to match(/.*#{@user.name}.*/i)
+    expect(page).to have_title("Motley User")
+    expect(page).to have_content(@user.name)
   end
 
   step 'I enter a registered email' do
@@ -36,15 +36,14 @@ class Spinach::Features::SignIn < Spinach::FeatureSteps
 
   step 'I click Sign In' do
     click_on "Sign in"
-    sync_page
   end
 
   step 'I see a success message containing "Signed in successfully"' do
     expect_flash(severity: :notice, containing: "Signed in successfully")
   end
 
-  step 'I see an alert containing "Invalid email or password"' do
-    expect_flash(severity: :alert, containing: "Invalid email or password")
+  step 'I see an alert containing "Invalid Email or password"' do
+    expect_flash(severity: :alert, containing: "Invalid Email or password")
   end
 
   step 'I see the new user name' do

--- a/features/steps/sign_out.rb
+++ b/features/steps/sign_out.rb
@@ -9,8 +9,7 @@ class Spinach::Features::SignOut < Spinach::FeatureSteps
   step 'I navigate to Sign Out' do
     find("li.navigation").hover
     click_link_or_button "Sign Out"
-    sync_page
-    expect(page.title).to eq("The Motley Tones")
+    expect(page).to have_title("The Motley Tones")
   end
 
   step 'I see a success message containing "Signed out successfully"' do

--- a/features/steps/user_management.rb
+++ b/features/steps/user_management.rb
@@ -21,15 +21,13 @@ class Spinach::Features::UserManagement < Spinach::FeatureSteps
   step 'I navigate to the Manage Pirates page' do
     find('li.navigation').hover
     click_link 'Manage Pirates'
-    sync_page
-    expect(page.title).to eq('Motley Users')
+    expect(page).to have_title('Motley Users')
   end
 
   step 'I navigate to the Profile page' do
     find('li.navigation').hover
     click_link 'Profile'
-    sync_page
-    expect(page.title).to eq('Motley User')
+    expect(page).to have_title('Motley User')
   end
 
   step 'I visit the Add Pirate page directly' do
@@ -91,19 +89,16 @@ class Spinach::Features::UserManagement < Spinach::FeatureSteps
   step 'I click Edit' do
     # need test to see that the page is for the right user
     click_on 'Edit Pirate'
-    sync_page
   end
 
   step 'I click Edit for that other user' do
     user_article(@another_user).click_on 'Edit'
-    sync_page
   end
 
   step 'I click Delete and confirm deletion for that other user' do
     my_accept_alert do
       user_article(@another_user).find('.delete').click
     end
-    sync_page
   end
 
   step 'that other user is deleted' do
@@ -116,7 +111,7 @@ class Spinach::Features::UserManagement < Spinach::FeatureSteps
   end
 
   step 'I see information for another user' do
-    expect(page.text).to have_content(@another_user.name)
+    expect(page).to have_content(@another_user.name)
   end
 
   step 'I see that the Band Start Date is not the first of this year' do
@@ -149,12 +144,10 @@ class Spinach::Features::UserManagement < Spinach::FeatureSteps
 
   step 'I click Add Pirate' do
     click_link_or_button 'Add pirate'
-    sync_page
   end
 
   step 'I click Add' do
     click_link_or_button 'Add'
-    sync_page
   end
 
   step 'the account is created' do
@@ -188,7 +181,6 @@ class Spinach::Features::UserManagement < Spinach::FeatureSteps
 
   step 'I click Update' do
     click_on 'Update'
-    sync_page
   end
 
   step 'the mutable fields are not changed' do
@@ -200,7 +192,7 @@ class Spinach::Features::UserManagement < Spinach::FeatureSteps
   end
 
   step 'I see my name on the users page' do
-    expect(find('.user_name').text).to match(@user.name)
+    expect(find('.user_name')).to have_content(@user.name)
   end
 
   step 'the mutable fields for that other user are changed' do
@@ -227,12 +219,10 @@ class Spinach::Features::UserManagement < Spinach::FeatureSteps
 
   step 'I click Cancel' do
     click_on 'Cancel'
-    sync_page
   end
 
   step 'I click Sign In' do
     click_on 'Sign in'
-    sync_page
   end
 
   step 'I am still in the admin account' do
@@ -262,10 +252,10 @@ class Spinach::Features::UserManagement < Spinach::FeatureSteps
 
   def expect_mutable_fields_to_be_changed(user) # rubocop: disable AbcSize
     within user_article(user) do
-      expect(find('.user_name').text).to       match(change(user.name))
-      expect(find('.user_tone_name').text).to  match(change(user.tone_name))
-      expect(find('.user_email').text).to      match(change(user.email))
-      expect(find('.user_start_date').text).to match(@changed_date)
+      expect(find('.user_name')).to       have_content(change(user.name))
+      expect(find('.user_tone_name')).to  have_content(change(user.tone_name))
+      expect(find('.user_email')).to      have_content(change(user.email))
+      expect(find('.user_start_date')).to have_content(@changed_date)
     end
     # unit testy way to check attribute changes
     expect(raw_mutable_attributes(User.find(user.id))).not_to eql(@original_raw_mutable_attributes)
@@ -273,10 +263,10 @@ class Spinach::Features::UserManagement < Spinach::FeatureSteps
 
   def expect_mutable_fields_not_to_be_changed(user) # rubocop: disable AbcSize
     within user_article(user) do
-      expect(find('.user_name').text).to       match(user.name)
-      expect(find('.user_tone_name').text).to  match(user.tone_name)
-      expect(find('.user_email').text).to      match(user.email)
-      expect(find('.user_start_date').text).to match(user.band_start_date.strftime('%d-%b-%Y'))
+      expect(find('.user_name')).to       have_content(user.name)
+      expect(find('.user_tone_name')).to  have_content(user.tone_name)
+      expect(find('.user_email')).to      have_content(user.email)
+      expect(find('.user_start_date')).to have_content(user.band_start_date.strftime('%d-%b-%Y'))
     end
     # unit testy way to check attribute constancy
     expect(raw_mutable_attributes(User.find(user.id))).to eql(@original_raw_mutable_attributes)

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -18,16 +18,12 @@ module Helpers
     do_login(@user, SOME_PASSWORD)
   end
 
-  def sync_page
-    page.has_css?("nav")
-  end
-
   def expect_flash(severity:, containing:)
-    expect(page.find(".flash .#{severity}").text).to match(/.*#{containing}.*/i)
+    expect(page.find(".flash .#{severity}")).to have_content(containing)
   end
 
   def expect_form_error(containing: nil)
-    expect(page.find(".form-error").text).to match(/.*#{containing}.*/i)
+    expect(page.find(".form-error")).to have_content(containing)
   end
 
   # Currently, poltergeist does not have the support for Capybara's accept_alert{}
@@ -57,6 +53,5 @@ module Helpers
     fill_in "user_email", with: user.email
     fill_in "user_password", with: password
     click_button 'Sign in'
-    sync_page
   end
 end


### PR DESCRIPTION
Certain tests failed intermittently and adding "#sync_page" and
"#sync_title()" calls smoothed over the problem.

In re-reading the paper describing Capybara's wait mechanisms,
https://www.varvet.com/blog/why-wait_until-was-removed-from-capybara/,
I discovered that the method being used for determining the page titles,
among other things, was causing the problem.

This commit fixes those calls, removes the timing issues and the
now uneeded methods.