### PR TITLE
TR #73 Adds test for picture separator in schedules

### DIFF
--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -34,9 +34,7 @@ footer
       .eight.columns
         ul.copyright
           li
-            | ©
-            => Time.now.strftime("%Y")
-            | The Motley Tones. All rights reserved.
+            = t('.copyright', year: Time.now.strftime("%Y"))
       .four.columns
         ul
           li.visit-count #{number_with_delimiter(Visit.count)} visitors

--- a/app/views/static_pages/_schedule.html.slim
+++ b/app/views/static_pages/_schedule.html.slim
@@ -1,5 +1,5 @@
-section.main-content
-  .row.schedule
+section
+  .row
     - current_year = nil
     ul
       - Gig.published.active.ascending.each do |gig|

--- a/app/views/static_pages/_separator_pic.html.slim
+++ b/app/views/static_pages/_separator_pic.html.slim
@@ -1,6 +1,6 @@
 - separator_file =  "schedule_separator.#{year}.jpg"
 - if year != Date.today.year && Rails.application.assets.find_asset(separator_file)
   hr
-  = image_tag separator_file, alt: "${year} separator", class: "image separator"
+  = image_tag separator_file, alt: "#{year} separator", class: "image separator separator-#{year}"
 h3 #{year} Performance Schedule
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,10 @@
 en:
   must_be_admin: "You must be an admin user to access that page."
+
   gig:
     added: "New gig added. There are now %{count} in the schedule."
     deleted: "Gig deleted. There are now %{count} in the schedule."
+
+  layouts:
+    footer:
+      copyright: "© %{year} The Motley Tones. All rights reserved."

--- a/spec/factories/gigs.rb
+++ b/spec/factories/gigs.rb
@@ -24,6 +24,12 @@ end
 # ensures that faked names are not invalid due to length
 def proper_length_name
   name = ""
-  name = Faker::Name.name until name.length > 13
+  name = "#{Faker::Commerce.product_name} #{day_type}" until name.length > 13
   name
+end
+
+def day_type
+  events = %w[ Festival Market Benefit Party Celebration ]
+  kind = %w[ Day Bash Meeting Gathering ].push("")
+  "#{events[rand(events.count).round]} #{kind[rand(kind.count).round]}"
 end

--- a/spec/features/static_pages_spec.rb
+++ b/spec/features/static_pages_spec.rb
@@ -1,42 +1,81 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe "static_pages" do
-  @copyright = "© The Motley Tones. All rights reserved"
+RSpec.describe 'static_pages', type: :feature do
+  @copyright = '© The Motley Tones. All rights reserved'
 
-  it "has a Root page" do
-    visit "/"
-    expect(page.title).to eq("The Motley Tones")
-    expect(page).to have_content(@copyright)
+  shared_examples 'it has standard decorations' do |title|
+    it 'has a title' do
+      expect(page).to have_title(title)
+    end
+
+    it 'has a copyright' do
+      within 'ul.copyright' do
+        expect(page).to have_content(I18n.t('layouts.footer.copyright', year: Time.now.strftime('%Y')))
+      end
+    end
   end
 
-  it "has an About page" do
-    visit "/about"
-    expect(page.title).to eq("Motley Tones: Past + Present")
-    expect(page).to have_content(@copyright)
+  context 'Root page' do
+    before { visit '/' }
+    it_behaves_like 'it has standard decorations', 'The Motley Tones'
+
+    it 'shows the performance schedule' do
+      3.times { FactoryGirl.create(:gig, published: true) }
+      visit '/'
+      within '.schedule' do
+        expect(page).to have_css('li', count: 3)
+      end
+    end
+
   end
 
-  it "has a Bios page" do
-    visit "/bios"
-    expect(page.title).to eq("Meet the Tones!")
-    expect(page).to have_content(@copyright)
+  context 'About page' do
+    before { visit '/about' }
+    it_behaves_like 'it has standard decorations', 'Motley Tones: Past + Present'
   end
 
-  it "has a Photos page" do
-    visit "/photos"
-    expect(page.title).to eq("Motley Pictures")
-    expect(page).to have_content(@copyright)
+  context 'Bios page' do
+    before { visit '/bios' }
+    it_behaves_like 'it has standard decorations', 'Meet the Tones!'
   end
 
-  it "has a Schedule page" do
-    visit "/schedule"
-    expect(page.title).to eq("Motley Performance Schedule")
-    expect(page).to have_content(@copyright)
+  context 'Photos page' do
+    before { visit '/photos' }
+    it_behaves_like 'it has standard decorations', 'Motley Pictures'
   end
 
-  it "has a Videos page" do
-    visit "/videos"
-    expect(page.title).to eq("Motley Videos")
-    expect(page).to have_content(@copyright)
+  context 'Schedule page' do
+    before do
+      2010.upto(2013).each do |year|
+        FactoryGirl.create(:gig, published: true, date: Date.new(year, 7, 10))
+      end
+      visit '/schedule'
+    end
+
+    it_behaves_like 'it has standard decorations', 'Motley Performance Schedule'
+
+    context 'has a gig list' do
+      it 'contains a list of gigs' do
+        Gig.all.each do |gig|
+          within '.main-content' do
+            expect(page).to have_css(".gig-id-#{gig.id}")
+          end
+        end
+      end
+
+      it 'a picture separates each year\'s gigs' do
+        within '.main-content' do
+          2010.upto(2013).each do |year|
+            expect(page).to have_css("img.separator-#{year}")
+          end
+        end
+      end
+    end
+  end
+
+  context 'Videos page' do
+    before { visit '/videos' }
+    it_behaves_like 'it has standard decorations', 'Motley Videos'
   end
 end


### PR DESCRIPTION
Also, adds tests to `static_pages` controller spec to ensure that the
schedule is showing in the root and schedule pages.  And refactors tests
to make them DRY and less susciptible to timing issues.