### PR TITLE
Fixes URL expansion bug

### DIFF
--- a/app/helpers/markup_helper.rb
+++ b/app/helpers/markup_helper.rb
@@ -23,7 +23,7 @@ module MarkupHelper
     # anchor_re#match breaks line up into MatchData elements as follows
     #      [1]            [2]           [3]            [4]
     # |leading text| |[link name]| |(link address)| |trailing text|
-    anchor_re = /(.*)\[(.*)\]\((.*)\)(.*)/
+    anchor_re = /(.*)\[(.*)\]\(([^)]*)\)(.*)/
     matches = anchor_re.match(raw)
 
     if matches


### PR DESCRIPTION
URL expansion ends with a closing paren, `)`.  The current implementation is swallowing all parens that follow.

This PR fixes that bug and enhances the tests.