### PR TITLE
Feature/do not strikout clone button TR234

### DIFF
--- a/app/assets/stylesheets/semantic_style.scss
+++ b/app/assets/stylesheets/semantic_style.scss
@@ -528,7 +528,7 @@ img.image.adjustable {
   margin: 0 0 2em 0;
 }
 
-.expired, .canceled {
+.strike-out {
   text-decoration: line-through;
 }
 

--- a/app/assets/stylesheets/semantic_style.scss
+++ b/app/assets/stylesheets/semantic_style.scss
@@ -528,7 +528,7 @@ img.image.adjustable {
   margin: 0 0 2em 0;
 }
 
-.strike-out {
+.expired, .canceled {
   text-decoration: line-through;
 }
 

--- a/app/views/gigs/_gig.html.slim
+++ b/app/views/gigs/_gig.html.slim
@@ -2,24 +2,26 @@ li
   = render 'gig_oneline', gig: gig, decoration: (decoration if defined? decoration)
 hr
 
-.schedule-information
-  p.gig-date.date class=(decoration if defined? decoration)
+.schedule-information class=(decoration if defined? decoration)
+  p.gig-date.date
     span.heading> Date:
     |
     span.gig-days #{date_thru_range(gig.date, gig.days)}
     - if gig.days > 1
       |  (#{gig.days} days)
-  p.gig-name class=(decoration if defined? decoration)
+  p.gig-name
     span.heading> Name:
     | #{gig.name}
-  p.gig-note class=(decoration if defined? decoration)
+  p.gig-note
     span.heading> Note:
     | #{gig.note}
-  p.gig-location class=(decoration if defined? decoration)
+  p.gig-location
     span.heading> Location:
     | #{gig.location}
-  p.gig-published.heading class=(decoration if defined? decoration)
+  p.gig-published.heading
     span> Published? #{(gig.published)? "Y" : "N"}
+
+.schedule-information
   p.gig-operations
     = link_to "Edit",
       edit_gig_path(gig),

--- a/app/views/gigs/_gig.html.slim
+++ b/app/views/gigs/_gig.html.slim
@@ -1,24 +1,24 @@
 li
-  = render 'gig_oneline', gig: gig
+  = render 'gig_oneline', gig: gig, decoration: (decoration if defined? decoration)
 hr
 
 .schedule-information
-  p.gig-date.date
+  p.gig-date.date class=(decoration if defined? decoration)
     span.heading> Date:
     |
     span.gig-days #{date_thru_range(gig.date, gig.days)}
     - if gig.days > 1
       |  (#{gig.days} days)
-  p.gig-name
+  p.gig-name class=(decoration if defined? decoration)
     span.heading> Name:
     | #{gig.name}
-  p.gig-note
+  p.gig-note class=(decoration if defined? decoration)
     span.heading> Note:
     | #{gig.note}
-  p.gig-location
+  p.gig-location class=(decoration if defined? decoration)
     span.heading> Location:
     | #{gig.location}
-  p.gig-published.heading
+  p.gig-published.heading class=(decoration if defined? decoration)
     span> Published? #{(gig.published)? "Y" : "N"}
   p.gig-operations
     = link_to "Edit",

--- a/app/views/gigs/_gig.html.slim
+++ b/app/views/gigs/_gig.html.slim
@@ -1,25 +1,27 @@
-li
-  = render 'gig_oneline', gig: gig, decoration: (decoration if defined? decoration)
-hr
+- expired = false unless defined? expired
+.gig class="#{canceled(gig) && 'canceled'} #{expired && 'expired'}"
+  li
+    = render 'gig_oneline', gig: gig
+  hr
 
-.schedule-information class=(decoration if defined? decoration)
-  p.gig-date.date
-    span.heading> Date:
-    |
-    span.gig-days #{date_thru_range(gig.date, gig.days)}
-    - if gig.days > 1
-      |  (#{gig.days} days)
-  p.gig-name
-    span.heading> Name:
-    | #{gig.name}
-  p.gig-note
-    span.heading> Note:
-    | #{gig.note}
-  p.gig-location
-    span.heading> Location:
-    | #{gig.location}
-  p.gig-published.heading
-    span> Published? #{(gig.published)? "Y" : "N"}
+  .schedule-information
+    p.gig-date.date
+      span.heading> Date:
+      |
+      span.gig-days #{date_thru_range(gig.date, gig.days)}
+      - if gig.days > 1
+        |  (#{gig.days} days)
+    p.gig-name
+      span.heading> Name:
+      | #{gig.name}
+    p.gig-note
+      span.heading> Note:
+      | #{gig.note}
+    p.gig-location
+      span.heading> Location:
+      | #{gig.location}
+    p.gig-published.heading
+      span> Published? #{(gig.published)? "Y" : "N"}
 
 .schedule-information
   p.gig-operations

--- a/app/views/gigs/_gig_oneline.html.slim
+++ b/app/views/gigs/_gig_oneline.html.slim
@@ -1,4 +1,4 @@
-span class=(decoration if defined? decoration)
+span
   span.gig-date.date #{date_range(gig.date, gig.days)}:
   span.gig-name      #{process_markup(gig.name)}
   - unless gig.note.blank?

--- a/app/views/gigs/_gig_oneline.html.slim
+++ b/app/views/gigs/_gig_oneline.html.slim
@@ -1,7 +1,8 @@
-span.gig-date.date #{date_range(gig.date, gig.days)}:
-span.gig-name      #{process_markup(gig.name)}
-- unless gig.note.blank?
-  span.gig-note<      #{process_markup(gig.note)}
-- unless gig.location.blank?
-  | ,
-  span.gig-location< #{process_markup(gig.location)}
+span class=(decoration if defined? decoration)
+  span.gig-date.date #{date_range(gig.date, gig.days)}:
+  span.gig-name      #{process_markup(gig.name)}
+  - unless gig.note.blank?
+    span.gig-note<      #{process_markup(gig.note)}
+  - unless gig.location.blank?
+    | ,
+    span.gig-location< #{process_markup(gig.location)}

--- a/app/views/gigs/index.html.slim
+++ b/app/views/gigs/index.html.slim
@@ -10,10 +10,10 @@ section.main-content.gig-management
       .row.schedule
         .ten.columns.offset-by-one
           article class="gig-id-#{gig.id} #{gig.published ? nil : 'unpublished'}"
-            = render "gig", gig: gig, decoration: canceled(gig) ? 'strike-out' : ''
+            = render "gig", gig: gig
 
     - @expired_gigs.each do |gig|
       .row.schedule
         .ten.columns.offset-by-one
           article class="gig-id-#{gig.id} #{gig.published ? nil : 'unpublished'}"
-            = render "gig", gig: gig, decoration: 'strike-out'
+            = render "gig", gig: gig, expired: true

--- a/app/views/gigs/index.html.slim
+++ b/app/views/gigs/index.html.slim
@@ -9,11 +9,11 @@ section.main-content.gig-management
     - @active_gigs.each do |gig|
       .row.schedule
         .ten.columns.offset-by-one
-          article class="gig-id-#{gig.id} #{canceled(gig) ? 'canceled' : ''} #{gig.published ? nil : 'unpublished'}"
-            = render "gig", gig: gig
+          article class="gig-id-#{gig.id} #{gig.published ? nil : 'unpublished'}"
+            = render "gig", gig: gig, decoration: canceled(gig) ? 'strike-out' : ''
 
     - @expired_gigs.each do |gig|
       .row.schedule
         .ten.columns.offset-by-one
-          article.expired class="gig-id-#{gig.id} #{gig.published ? nil : 'unpublished'}"
-            = render "gig", gig: gig
+          article class="gig-id-#{gig.id} #{gig.published ? nil : 'unpublished'}"
+            = render "gig", gig: gig, decoration: 'strike-out'


### PR DESCRIPTION
Removes strikethrough styling from Gig buttons.  Also, marks cancelled gigs with a strikethrough when 'Cancelled:' appears in the event name.