### PR TITLE
Improves code for APP_VERSION value setting

### DIFF
--- a/config/initializers/app_version.rb
+++ b/config/initializers/app_version.rb
@@ -2,14 +2,9 @@
 # Set the app version based on the first 7 characters of CircleCI or Railway environment variables.
 # Fallback to a default value if the variable is not set (e.g., in development).
 abbrev_len = 7
-sha = ENV['RAILWAY_GIT_COMMIT_SHA'] || ENV['APP_VERSION'] || 'dev'
+sha = ENV['RAILWAY_GIT_COMMIT_SHA'] || ENV['APP_VERSION'] || 'test'
 APP_VERSION = if sha.length > abbrev_len
                 sha[0..(abbrev_len - 1)]
               else
                 sha
               end
-
-puts "---------------------------------- env '#{ENV['RAILWAY_GIT_COMMIT_SHA']}'"
-puts "---------------------------------- env '#{ENV['APP_VERSION']}'"
-puts "---------------------------------- lcl '#{sha}'"
-puts "---------------------------------- gbl '#{APP_VERSION}'"


### PR DESCRIPTION
Improves code so that it will work with long or short SHAs by only using the first 7 characters of whatever is found  in the envars.